### PR TITLE
Rails 3 Support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ begin
     gem.homepage = "http://github.com/jamesgolick/action_mailer_verp"
     gem.authors = ["James Golick"]
     gem.add_development_dependency "rspec", ">= 1.2.9"
-    gem.add_dependency "actionmailer", "~> 2.3.1"
+    gem.add_dependency "actionmailer", "~> 3.0.5"
     # gem is a Gem::Specification... see http://www.rubygems.org/read/chapter/20 for additional settings
   end
   Jeweler::GemcutterTasks.new

--- a/lib/action_mailer_verp.rb
+++ b/lib/action_mailer_verp.rb
@@ -1,4 +1,4 @@
-require 'actionmailer'
+require 'action_mailer'
 require 'action_mailer_verp/bounce_processor'
 require 'action_mailer_verp/pop_fetcher'
 
@@ -7,14 +7,10 @@ module ActionMailerVerp
     class MultipleFromsError < ArgumentError; end
     class MultipleRecipientsError < ArgumentError; end
 
-    def self.included(klass)
-      klass.send(:alias_method_chain, :create_mail, :verp)
-    end
-
-    def create_mail_with_verp
-      create_mail_without_verp
-      verpify(@mail)
-      @mail
+    def mail(*args, &block)
+      m = super
+      verpify(m)
+      m
     end
 
     private
@@ -27,9 +23,11 @@ module ActionMailerVerp
           raise MultipleRecipientsError, "Multiple recipients not supported."
         end
 
-        from                = mail.from_addrs.first
-        local               = "#{from.local}+#{mail.to.first.gsub("@", "=")}"
-        return_path         = "#{local}@#{from.domain}"
+        from_parts          = mail.from_addrs.first.split(/@/)
+        from_local          = from_parts.first
+        from_domain         = from_parts.last
+        local               = "#{from_local}+#{mail.to.first.gsub("@", "=")}"
+        return_path         = "#{local}@#{from_domain}"
         mail['return-path'] = return_path
       end
   end

--- a/spec/action_mailer_verp_spec.rb
+++ b/spec/action_mailer_verp_spec.rb
@@ -3,44 +3,44 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 describe "ActionMailerVerp" do
   class MyMailer < ActionMailer::Base
     include ActionMailerVerp::VERPMail
-    self.template_root = File.dirname(__FILE__) + "/templates"
+    prepend_view_path File.dirname(__FILE__) + "/templates"
 
     def some_mail(address)
-      from "MyCompany <donotreply@mycompany.com>"
-      recipients address
-      subject "An exciting new email from MyCompany"
+      mail :from    => "MyCompany <donotreply@mycompany.com>",
+           :to      => address,
+           :subject => "An exciting new email from MyCompany"
     end
 
     def multiple_froms
-      from ["MyCompany <donotreply@mycompany.com>", "AnotherFrom <asdf@bsdf.com>"]
-      recipients "asdf@bsdf.com"
-      subject "An exciting new email from MyCompany"
+      mail :from    => ["MyCompany <donotreply@mycompany.com>", "AnotherFrom <asdf@bsdf.com>"],
+           :to      => "asdf@bsdf.com",
+           :subject => "An exciting new email from MyCompany"
     end
 
     def multiple_recipients
-      from "MyCompany <donotreply@mycompany.com>"
-      recipients ["asdf@bsdf.com", "bsdf@csdf.com"]
-      subject "An exciting new email from MyCompany"
+      mail :from    => "MyCompany <donotreply@mycompany.com>",
+           :to      => ["asdf@bsdf.com", "bsdf@csdf.com"],
+           :subject => "An exciting new email from MyCompany"
     end
   end
 
   describe "ActionMailerVerp::VERPMail" do
     describe "with one from address" do
       before do
-        @mail = MyMailer.create_some_mail("james@example.com")
+        @mail = MyMailer.some_mail("james@example.com")
       end
 
       it "sets the return-path to the VERP address" do
-        addr = @mail['return-path'].addr
-        addr.local.should == "donotreply+james=example.com"
-        addr.domain.should == "mycompany.com"
+        addr = @mail['return-path'].value.split(/@/)
+        addr.first.should == "donotreply+james=example.com"
+        addr.last.should == "mycompany.com"
       end
     end
-    
+
     describe "with multiple from addresses" do
       it "raises an error because that is not supported" do
         lambda {
-          MyMailer.create_multiple_froms
+          MyMailer.multiple_froms
         }.should raise_error(ActionMailerVerp::VERPMail::MultipleFromsError)
       end
     end
@@ -48,7 +48,7 @@ describe "ActionMailerVerp" do
     describe "with multiple recipients" do
       it "raises an error because that is not supported" do
         lambda {
-          MyMailer.create_multiple_recipients
+          MyMailer.multiple_recipients
         }.should raise_error(ActionMailerVerp::VERPMail::MultipleRecipientsError)
       end
     end


### PR DESCRIPTION
This patch works with ActionMailer from Rails 3.  I did not attempt to support both Rails 2 and 3 as I assume it is easy enough to just specify the old version as the dependency.  Thanks for putting this code out there!
